### PR TITLE
Implement JSON service info endpoint with TDD tests

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -33,10 +33,14 @@ from service.common import status  # HTTP Status Codes
 @app.route("/")
 def index():
     """Root URL response"""
-    return (
-        "Reminder: return some useful information in json format about the service here",
-        status.HTTP_200_OK,
-    )
+    return jsonify(
+        name="Promotions Service",
+        version="1.0.0",
+        description="RESTful service for managing promotions",
+        paths={
+            "promotions": "/promotions",
+        }
+    ), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -71,5 +71,10 @@ class TestYourResourceService(TestCase):
         """It should call the home page"""
         resp = self.client.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data["name"], "Promotions Service")
+        self.assertEqual(data["version"], "1.0.0")
+        self.assertEqual(data["description"], "RESTful service for managing promotions")
+        self.assertIn("promotions", data["paths"])
 
     # Todo: Add your test cases here...


### PR DESCRIPTION
## Related issue

#7

## Summary
Update root route to return service information as `JSON` response instead of plain text reminder.

## What

  - Modified `/` endpoint to return structured `JSON` with service metadata
  - Enhanced test coverage to validate `JSON` response structure and content
