### PR TITLE
Implement POST endpoint with validation

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -47,4 +47,72 @@ def index():
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################
 
-# Todo: Place your REST API code here ...
+######################################################################
+# LIST ALL PETS
+######################################################################
+
+######################################################################
+# READ A PET
+######################################################################
+
+######################################################################
+# CREATE A NEW PROMOTION
+######################################################################
+@app.route("/promotions", methods=["POST"])
+def create_promotions():
+    """
+    Create a Promotion
+    This endpoint will create a Promotion based the data in the body that is posted
+    """
+    app.logger.info("Request to Create a Promotion...")
+    check_content_type("application/json")
+
+    promotion = Promotion()
+    # Get the data from the request and deserialize it
+    data = request.get_json()
+    app.logger.info("Processing: %s", data)
+    promotion.deserialize(data)
+
+    # Save the new Promotion to the database
+    promotion.create()
+    app.logger.info("Promotion with new id [%s] saved!", promotion.id)
+
+    # Return the location of the new Promotion
+    location_url = url_for("get_promotions", promotion_id=promotion.id, _external=True)
+    return jsonify(promotion.serialize()), status.HTTP_201_CREATED, {"Location": location_url}
+
+######################################################################
+# UPDATE A NEW PROMOTION
+######################################################################
+
+######################################################################
+# DELETE A NEW PROMOTION
+######################################################################
+
+######################################################################
+# U T I L I T Y   F U N C T I O N S
+######################################################################
+
+
+######################################################################
+# Checks the ContentType of a request
+######################################################################
+
+
+def check_content_type(content_type):
+    """Checks that the media type is correct"""
+    if "Content-Type" not in request.headers:
+        app.logger.error("No Content-Type specified.")
+        abort(
+            status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            f"Content-Type must be {content_type}",
+        )
+
+    if request.headers["Content-Type"] == content_type:
+        return
+
+    app.logger.error("Invalid Content-Type: %s", request.headers["Content-Type"])
+    abort(
+        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+        f"Content-Type must be {content_type}",
+    )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,8 +2,8 @@
 Test Factory to make fake objects for testing
 """
 
-import factory
 from datetime import date, timedelta
+import factory
 from service.models import Promotion
 
 
@@ -20,5 +20,5 @@ class PromotionFactory(factory.Factory):
     promotion_type = factory.Faker("random_element", elements=("Percentage off", "Buy One Get One", "Fixed amount off"))
     value = factory.Faker("random_int", min=1, max=99)
     product_id = factory.Faker("random_int", min=1, max=1000)
-    start_date = factory.LazyFunction(lambda: date.today())
+    start_date = factory.LazyFunction(date.today())
     end_date = factory.LazyFunction(lambda: date.today() + timedelta(days=30))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,8 +22,8 @@ Test cases for Promotion Model
 import os
 import logging
 from unittest import TestCase
-from wsgi import app
 from datetime import date
+from wsgi import app
 from service.models import Promotion, DataValidationError, db
 from tests.factories import PromotionFactory
 


### PR DESCRIPTION
## Related issue
#1

## What
  - Implement `create_promotions` endpoint with proper validation
  - Add test suite including happy and sad paths
  - Include error handling for missing data, wrong content-type, and bad types
  - Follow REST API best practices with 201 Created and Location header (waiting for `get_promotions`)
  - Update all imports to use Promotion model consistently