### PR TITLE
Fix: add utility function for tests to bulk create promotions

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -20,5 +20,5 @@ class PromotionFactory(factory.Factory):
     promotion_type = factory.Faker("random_element", elements=("Percentage off", "Buy One Get One", "Fixed amount off"))
     value = factory.Faker("random_int", min=1, max=99)
     product_id = factory.Faker("random_int", min=1, max=1000)
-    start_date = factory.LazyFunction(date.today())
+    start_date = factory.LazyFunction(date.today)
     end_date = factory.LazyFunction(lambda: date.today() + timedelta(days=30))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -65,6 +65,22 @@ class TestPromotionService(TestCase):
         """This runs after each test"""
         db.session.remove()
 
+    ############################################################
+    # Utility function to bulk create promotions
+    ############################################################
+    def _create_promotions(self, count: int = 1) -> list:
+        """Factory method to create promotions in bulk"""
+        promotions = []
+        for _ in range(count):
+            test_promotion = PromotionFactory()
+            response = self.client.post(BASE_URL, json=test_promotion.serialize())
+            self.assertEqual(
+                response.status_code, status.HTTP_201_CREATED, "Could not create test promotion"
+            )
+            new_promotion = response.get_json()
+            test_promotion.id = new_promotion["id"]
+            promotions.append(test_promotion)
+        return promotions
     ######################################################################
     #  T E S T   C A S E S
     ######################################################################


### PR DESCRIPTION
## Why 
The `Get` tests were failing due to the lack of method to create multiple promotions for test setups.
## What
Added `_create_promotions`
## Screenshot
<img width="1157" height="706" alt="CleanShot 2025-10-10 at 00 48 53" src="https://github.com/user-attachments/assets/3f672148-1a21-4fb8-b6be-8fa264c0d1a3" />
