### PR TITLE
QueryActivePromotions

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -204,8 +204,18 @@ class Promotion(db.Model):
             return []
         return list(cls.query.filter(cls.product_id == pid).all())
 
-    # --- Backward-compatible alias for older code paths (optional but harmless) ---
-    # @classmethod
-    # def find_by_category(cls, category):
-    #     """Deprecated alias: 'category' == 'product_id'. Keeps older callers working."""
-    #     return cls.find_by_product_id(category)
+    @classmethod
+    def find_active(cls, on_date: date | None = None) -> list["Promotion"]:
+        """
+        Returns all Promotions that are active on the given date (inclusive).
+        Active means: start_date <= on_date <= end_date.
+
+        """
+        if on_date is None:
+            on_date = date.today()
+        return list(
+            cls.query.filter(
+                cls.start_date <= on_date,
+                cls.end_date >= on_date,
+            ).all()
+        )

--- a/service/routes.py
+++ b/service/routes.py
@@ -48,32 +48,35 @@ def index():
 
 ######################################################################
 # LIST Promotions with optional filters
-# Supported:
-#   ?id=<int>              -> single record as [ ... ] or []
-#   ?name=<str>            -> exact match list
-#   ?product_id=<int>      -> exact match list
-#   ?promotion_type=<str>  -> exact match list
+# List Promotions
+# - Without query: return all promotions
+# - With filter: return exact matches
+#
+# Supported query params:
+# ?id=<int>              -> single record as [ ... ] or []
+# ?active=true           -> list of promotions active "today" (server date)
+# ?name=<str>            -> exact match list
+# ?product_id=<int>      -> exact match list
+# ?promotion_type=<str>  -> exact match list
+# Priority: id > active > name > product_id > promotion_type > all
 ######################################################################
 @app.route("/promotions", methods=["GET"])
 def list_promotions():
-    """
-    List Promotions
-    - Without query: return all promotions
-    - With filter: return exact matches
-    """
     app.logger.info("Request to list Promotions")
 
-    # Parse filters
     promotion_id = request.args.get("id")
+    active = request.args.get("active")
     name = request.args.get("name")
     product_id = request.args.get("product_id")
     ptype = request.args.get("promotion_type")
 
-    # Apply a simple precedence so multiple params don't surprise: id > name > product_id > promotion_type
     if promotion_id:
         app.logger.info("Filtering by id=%s", promotion_id)
         p = Promotion.find(promotion_id)
         promotions = [p] if p else []
+    elif active and str(active).lower() == "true":
+        app.logger.info("Filtering by active promotions (server date)")
+        promotions = Promotion.find_active()
     elif name:
         app.logger.info("Filtering by name=%s", name)
         promotions = Promotion.find_by_name(name.strip())
@@ -168,7 +171,6 @@ def update_promotions(promotion_id: int):
         abort(status.HTTP_400_BAD_REQUEST, str(error))
 
     return jsonify(promotion.serialize()), status.HTTP_200_OK
-
 
 
 ######################################################################


### PR DESCRIPTION
## Add Query Promotions by Active Status

### What’s New

This PR implements a new query feature in the Promotions API, allowing marketing managers to easily retrieve a list of **currently active promotions** without manually comparing start and end dates.

* **New query parameter:** `active=true`
* Defines "active" promotions as those with the current server date between their `start_date` and `end_date` (**inclusive**).
* Adds corresponding unit and integration tests covering various scenarios (active, expired, future promotions).

### Motivation (Why)

Marketing managers currently have to manually check each promotion's dates to determine which promotions are active. This is cumbersome, error-prone, and inefficient.

By providing a built-in "active promotions" filter, we simplify operational processes and reduce the risk of human error, aligning directly with business needs.

### Changes Made

#### Service Layer

* Added new model method:

  ```python
  Promotion.find_active(on_date=None)
  ```

  This method returns all promotions that are active today (server-side date).

#### API Layer (Routes)

* Extended `GET /promotions` route to support filtering by active status:

  ```
  GET /promotions?active=true
  ```
* Implemented clear priority order for query parameters:
  `id > active > name > product_id > promotion_type > all`

#### Tests

* **Unit tests** for the new model method (`find_active`), ensuring correctness of date comparisons.
* **Integration tests** for API endpoint verifying the correct promotions are returned when filtered by `active=true`.
* Edge cases tested explicitly:

  * Promotions starting/ending exactly today.
  * Promotions already expired or not yet started.

### Acceptance Criteria Met

* Given a promotion exists with a start date in the past and an end date in the future,
  And another promotion exists with an end date in the past,
  When I send a `GET` request to `/promotions?active=true`,
  Then I should receive a response with a `200 OK` status code,
  And the response body contains **ONLY** the currently active promotions.

### Impact

* Clearer API semantics for querying promotions.
* Increased efficiency and accuracy for marketing managers.
* Robust and comprehensive test coverage to safeguard future changes.

### How to Test

1. Pull this branch:

   ```bash
   git checkout <feature-branch-name>
   ```
2. Ensure dependencies are up-to-date:

   ```bash
   make install
   ```
3. Run all tests to verify:

   ```bash
   make test
   ```
4. (Optional) Manually test via API client or browser:

   ```bash
   GET /promotions?active=true
   ```

### Notes

* The solution is backward-compatible and does not impact existing functionality.
