### PR TITLE
K8S-02: Rename container image to `promotions` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # These can be overidden with env vars.
 REGISTRY ?= cluster-registry:5000
-IMAGE_NAME ?= petshop
+IMAGE_NAME ?= promotions
 IMAGE_TAG ?= 1.0
 IMAGE ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 PLATFORM ?= "linux/amd64,linux/arm64"


### PR DESCRIPTION
Standardize the container image name for this repo by changing `IMAGE_NAME` from `petshop` → `promotions`. This aligns the build/push artifacts with the project identity and unblocks Kubernetes manifests that reference `cluster-registry:5000/promotions:1.0`.

### Why / Context

* The repo’s Makefile still used a legacy image name (`petshop`).
* Our K8s deployment plan (Req. 3) expects the image `cluster-registry:5000/promotions:1.0`.
* Without this change, `make build/push/deploy` would publish the wrong image tag, and the Deployment would fail to pull the expected image.

### What Changed

**Makefile**

```diff
REGISTRY ?= cluster-registry:5000
- IMAGE_NAME ?= petshop
+ IMAGE_NAME ?= promotions
IMAGE_TAG ?= 1.0
IMAGE ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
```

### Before / After

* **Before:** `cluster-registry:5000/petshop:1.0`
* **After:**  `cluster-registry:5000/promotions:1.0`

### How I Tested

Local, using the new image name:

```bash
# Optional: create local K3D cluster with registry
make cluster

# Build & push now target cluster-registry:5000/promotions:1.0
make build
make push

# Sanity run (if Dockerfile already added in K8S-01)
docker run --rm -p 8080:8080 cluster-registry:5000/promotions:1.0
curl -i http://localhost:8080/
# Expect: 200 OK and service JSON on "/"
```

CI remained green (no code paths altered; only Makefile var updated).

### Impact

* Aligns image naming with project (`promotions`).
* Unblocks upcoming issues:

  * K8S-04/05/06: `k8s/deployment.yaml/service.yaml/ingress.yaml` will reference `cluster-registry:5000/promotions:1.0`.
* No runtime or API behavior change.

### Risks & Mitigations

* **Risk:** If any scripts still hard-code `petshop`, builds could diverge.
  **Mitigation:** Searched repo for `petshop` usage in Makefile targets; only this variable required change.
* **Risk:** Consumers pulling the old tag may fail.
  **Mitigation:** We are not publishing the old tag from this repo; downstream should pull `promotions`.

### Rollback Plan

Revert this commit to restore `IMAGE_NAME ?= petshop`. No DB/data migration involved.

### Related

* Tracks **K8S-02** in the “Requirement 3 – Deploy to Kubernetes” milestone.
* Follow-ups: K8S-03 `/health` endpoint; K8S-04/05/06 K8s manifests.

### Checklist

* [x] Build produces `cluster-registry:5000/promotions:1.0`
* [x] Push works against local K3D registry
* [x] No CI regressions
* [x] No functional code changes outside Makefile

