### PR TITLE
K8S-04: Add Kubernetes Deployment for Promotions Service

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: promotions-deployment
+  namespace: default
+  labels:
+    app: promotions
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: promotions
+  template:
+    metadata:
+      labels:
+        app: promotions
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: promotions
+          image: cluster-registry:5000/promotions:1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            # Explicitly set runtime mode and port (wsgi.py also defaults to 8080; being explicit is clearer)
+            - name: FLASK_ENV
+              value: "production"
+            - name: PORT
+              value: "8080"
+            # Connect to the in-cluster Postgres (K8S-07/08 will create a Service named `postgres`)
+            - name: DATABASE_URI
+              value: "postgresql+psycopg://postgres:postgres@postgres:5432/promotions"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 2
+            failureThreshold: 3
+          # If you need to control resources on the remote cluster, add requests/limits in K8S-13
+          # resources:
+          #   requests:
+          #     cpu: "100m"
+          #     memory: "128Mi"
+          #   limits:
+          #     cpu: "500m"
+          #     memory: "512Mi"


### PR DESCRIPTION
Adds a production-ready `Deployment` manifest to run the Promotions service on Kubernetes. The spec pins the app image, exposes port **8080**, wires **/health** for readiness/liveness, and injects a cluster-internal Postgres **DATABASE_URI**. No application code changes.

---

### What changed

* **Added:** `k8s/deployment.yaml`

  * `kind: Deployment`, `metadata.name: promotions-deployment`, labels `app: promotions`
  * `replicas: 1`, `revisionHistoryLimit: 2`, `terminationGracePeriodSeconds: 30`
  * **Container**

    * `image: cluster-registry:5000/promotions:1.0` (from K8S-01/02)
    * `ports: 8080` (name `http`)
    * `env`:

      * `FLASK_ENV=production`
      * `PORT=8080`
      * `DATABASE_URI=postgresql+psycopg://postgres:postgres@postgres:5432/promotions`
    * **Probes**: readiness & liveness `GET /health` on `8080`
    * `imagePullPolicy: IfNotPresent`

> Notes
>
> * The `DATABASE_URI` targets Service `postgres` which will be created in K8S-07/08.
> * Probes use the lightweight `/health` endpoint added in K8S-03.

---

### Why

Provides the minimal, declarative spec to schedule and supervise the app in K8s (probe-driven availability, predictable env, and image pinning), unblocking Service/Ingress and DB manifests in upcoming tasks.

---

### How to test (local K3D/K3S)

1. Build & push the image to the local registry (same registry the cluster can pull from):

```bash
docker build -t localhost:5000/promotions:1.0 .
docker push localhost:5000/promotions:1.0
```

2. Apply the deployment:

```bash
kubectl apply -f k8s/deployment.yaml
kubectl get pods -w
kubectl logs deploy/promotions-deployment
```

3. If you see `ErrImagePull`, ensure you pushed to **localhost:5000** and then:

```bash
kubectl rollout restart deployment/promotions-deployment
```

4. Expect the pod to become **READY 1/1** once the image is available and `/health` passes.

> Until the Postgres StatefulSet/Service (K8S-07/08) land, the app may transiently fail if it tries to connect at startup. Deploy DB first for a clean boot. Probes themselves do not hit the DB.

---

### Risks & mitigations

* **Image pull failures** → Push to `localhost:5000`, keep `image: cluster-registry:5000/...`, then `rollout restart`.
* **DB not yet available** → Deploy Postgres before/after; app may restart until DB is up. Mitigated in K8S-07/08.
* **Probe misconfig** → `/health` is dependency-free; if changed in the future, keep it lightweight to avoid false negatives.

---

### Rollback

```bash
kubectl rollout undo deployment/promotions-deployment
# or
kubectl delete -f k8s/deployment.yaml
```

---

### Related work

* **Depends on:** K8S-01 (Dockerfile), K8S-02 (Makefile image name), K8S-03 (/health)
* **Follow-ups:** K8S-05 (Service), K8S-06 (Ingress), K8S-07/08 (Postgres SS/Service)

---

### Checklist

* [x] Added `k8s/deployment.yaml`
* [x] Probes point to `/health` (ready/live)
* [x] Image name aligns with Makefile (`promotions:1.0`)
* [x] Local build/push/apply instructions included
* [x] No app code changes, CI unaffected

