### PR TITLE
K8S-05: Add ClusterIP Service for Promotions (80 → 8080)

### DIFF
--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: promotions-service
+  namespace: default
+  labels:
+    app: promotions
+spec:
+  type: ClusterIP
+  selector:
+    app: promotions
+  ports:
+    - name: http
+      port: 80         # Port to access the Service within the cluster
+      targetPort: http # Points to the Pod container port 8080 (named "http" in deployment.yaml)
+      protocol: TCP


### PR DESCRIPTION
Create a stable in-cluster endpoint for the `promotions` Deployment by introducing a `ClusterIP` Service named `promotions-service`. This Service exposes port **80** and forwards to the container’s named port **`http` (8080)**, enabling Ingress (K8S-06) and internal discovery.

### What changed

* **Added** `k8s/service.yaml`

  * `kind: Service`, `type: ClusterIP`
  * `metadata.name: promotions-service`
  * `spec.selector.app: promotions` (matches Deployment labels)
  * `ports[0]: name=http, port=80, targetPort=http, protocol=TCP`

### Why

* Provide a stable DNS entry (`promotions-service.default.svc.cluster.local`) for the app Pods.
* Serve as the backend target for the upcoming Ingress (K8S-06).
* Decouple Pod IP churn from clients and routing.

### How to test (manual)

```bash
# Apply only the Service
kubectl apply -f k8s/service.yaml

# Verify the Service and endpoints
kubectl get svc promotions-service -o wide
kubectl get endpoints promotions-service -o wide
kubectl get pods -l app=promotions

# Port-forward to validate traffic to the Pod (80 -> 8080)
kubectl port-forward svc/promotions-service 8088:80

# Probe health & root
curl -i http://localhost:8088/health   # expect 200, {"status":"OK"}
curl -i http://localhost:8088/         # expect 200, service JSON
```

### Acceptance criteria

* `promotions-service` exists and selects the running `promotions` Pod(s).
* Endpoints populated with the Pod’s `:8080`.
* `curl` via port-forward returns **200** for `/health` and `/`.

### Dependencies / Ordering

* **Requires:** K8S-04 Deployment (`app: promotions` label, container port named `http` at 8080).
* **Unblocks:** K8S-06 Ingress (routes external traffic to `promotions-service:80`).
* **DB note:** Postgres (K8S-07/08) not required to validate `/health`/`/`.

### Risks & mitigations

* **Selector mismatch** → No endpoints.
  *Mitigation:* Keep `spec.selector.app: promotions` aligned with Deployment labels.
* **Port mismatch** → 404/connection errors.
  *Mitigation:* Use `targetPort: http` (the named container port) or explicitly `8080`.


### Security / Breaking changes

* None.

### Linked work

* Issue: **K8S-05**
* Related: K8S-04 (Deployment), K8S-06 (Ingress)

