### PR TITLE
K8S-06: Add Ingress for Promotions Service

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: promotions-ingress
+  namespace: default
+  labels:
+    app: promotions
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: promotions.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: promotions-service
+                port:
+                  number: 80
+# If TLS is needed, enable as appropriate (example):
+# tls:
+#   - hosts:
+#       - promotions.local
+#     secretName: promotions-tls


### PR DESCRIPTION
Expose the `promotions-service` outside the cluster via an HTTP Ingress. This enables testing the app through a stable hostname after K8S-04 (Deployment) and K8S-05 (Service) are in place.

### What changed

* **Added** `k8s/ingress.yaml`

  * `ingressClassName: traefik` (K3D/K3S default)
  * `host: promotions.local`
  * Route `"/"` → `promotions-service:80` (→ Pod `8080`)
* **No** application code changes.
* **No** changes to existing Deployment/Service manifests.

### Why

* Provide a single, stable entrypoint for manual verification, demos, and future automation through the cluster’s edge (LB/Ingress).
* Aligns with Requirement 3 (Deploy to Kubernetes).

### How to test (K3D/K3S – Traefik)

1. Apply:

   ```bash
   kubectl apply -f k8s/ingress.yaml
   kubectl get ingress promotions-ingress -o wide
   ```
2. Hostname:

   * Option A: add to `/etc/hosts`
     `127.0.0.1  promotions.local`
   * Option B: use nip.io (change host in manifest to `promotions.127.0.0.1.nip.io`)
3. Verify:

   ```bash
   # with Host header (no /etc/hosts needed)
   curl -i -H "Host: promotions.local" http://localhost:8080/health
   # Expected: HTTP/1.1 200 OK and {"status":"OK"}
   ```

### Acceptance criteria

* `kubectl apply -f k8s/ingress.yaml` succeeds with a ready `promotions-ingress`.
* `curl -H "Host: promotions.local" http://localhost:8080/health` returns **200** with `{"status":"OK"}`.
* No regressions to Deployment/Service; app Pod remains **Ready 1/1**.

### Risks & mitigations

* **404 via Ingress**: typically Host mismatch or wrong ingress class.
  *Mitigation*: verify `ingressClassName`, `host` DNS, and `service.name/port`.
* **Connectivity issues**: ensure K3D cluster exposes LB `80 → host:8080` (created by `make cluster`).

### Rollback

```bash
kubectl delete -f k8s/ingress.yaml
```

Service remains reachable in-cluster (and via `kubectl port-forward`).

### Docs/Follow-ups

* (Docs) Add a short “Access via Ingress” section to README with `/etc/hosts`/nip.io instructions.
* (Next) K8S-07/08: add PostgreSQL StatefulSet/Service; confirm end-to-end DB connectivity via Ingress.

### Related

* Depends on: K8S-04 (Deployment), K8S-05 (Service)
* Closes: K8S-06

### Release note

External HTTP access enabled via Ingress: `http://promotions.local:8080` → `promotions-service`.
