### PR TITLE
K8S-07: Add PostgreSQL StatefulSet

### DIFF
--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -1,0 +1,89 @@
+# -----------------------------------------------
+# Headless Service for StatefulSet (stable identity)
+# -----------------------------------------------
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-hl
+  namespace: default
+  labels:
+    app: postgres
+spec:
+  clusterIP: None                 # Headless service
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+# -----------------------------------------------
+# PostgreSQL StatefulSet
+# -----------------------------------------------
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: default
+  labels:
+    app: postgres
+spec:
+  serviceName: postgres-hl        # Bind to the Headless Service above
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      # Avoid local storage permission issues (common with local-path scenarios)
+      securityContext:
+        runAsUser: 999            # UID of the postgres user
+        runAsGroup: 999
+        fsGroup: 999              # Make the mounted volume writable by the postgres group
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: "promotions"        # Database name (aligned with the service resource name)
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              value: "postgres"
+          # Readiness and liveness probes (using pg_isready)
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres", "-d", "promotions"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres", "-d", "promotions"]
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: pgdata
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        # Leave empty to use the default StorageClass (K3D/K3S is usually local-path)
+        # If you need to specify one explicitly, uncomment and set your StorageClass name:
+        # storageClassName: local-path
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
Introduce a production-like PostgreSQL setup for the promotions service by adding a **StatefulSet** with persistent storage and a **headless Service** for stable DNS identity. This lays the groundwork for in-cluster DB connectivity and durability in our Kubernetes environment.

### What & Why

* **What:** Create `k8s/postgres/statefulset.yaml` that defines:

  * Headless Service `postgres-hl` (for StatefulSet identity).
  * StatefulSet `postgres` (1 replica) using `postgres:15-alpine`, persistent volume (1 Gi), and readiness/liveness probes.
* **Why:** We need a reliable, stateful Postgres instance for local K8s deployments. This enables the app to run fully in-cluster with durable data, and unblocks downstream wiring via a ClusterIP Service (`K8S-08`).

### Changes

* **Added:** `k8s/postgres/statefulset.yaml`

  * Headless Service: `postgres-hl` (ClusterIP: None).
  * StatefulSet: `postgres` with:

    * `POSTGRES_DB=promotions`, `POSTGRES_USER=postgres`, `POSTGRES_PASSWORD=postgres` (dev only).
    * `volumeClaimTemplates` (1 Gi; default StorageClass, e.g., `local-path` on K3D/K3S).
    * Probes using `pg_isready` (readiness & liveness).
    * `securityContext` with `fsGroup: 999` to avoid local-path permission issues.
* **No changes** to application code, CI, or existing manifests.

### How to Deploy

```bash
kubectl apply -f k8s/postgres/statefulset.yaml
kubectl get statefulset postgres
kubectl get pods -l app=postgres
kubectl logs postgres-0
```

**Expected:** Pod `postgres-0` becomes `Running` and `READY 1/1`; logs include “database system is ready to accept connections”.

**Optional smoke test:**

```bash
kubectl exec -it postgres-0 -- psql -U postgres -d promotions -c "SELECT 1;"
```

### Acceptance Criteria

* ✅ `postgres-0` pod is `Running` and `READY 1/1`.
* ✅ Readiness/liveness probes pass (`pg_isready`).
* ✅ PVC is `Bound` (1 Gi) with the cluster’s default StorageClass.
* ✅ No changes or regressions in CI.
* ✅ App **not yet wired** to DB (that happens in K8S-08 via a ClusterIP Service named `postgres`).

### Notes / Dependencies

* **Service naming:** The app will connect via **`postgres`** (ClusterIP Service added in **K8S-08**). Do **not** point the app at `postgres-hl`; that service is headless and intended for StatefulSet identity only.
* **DATABASE_URI (already in deployment):**

  ```
  postgresql+psycopg://postgres:postgres@postgres:5432/promotions
  ```

  This will work once K8S-08 creates `Service/postgres`.

### Risks & Mitigations

* **PVC Pending:** If no default StorageClass, PVC may remain `Pending`.
  *Mitigation:* Specify `storageClassName` (e.g., `local-path`) or temporarily switch to `emptyDir` for non-persistent dev runs.
* **Permission errors on local-path:** Addressed via `fsGroup: 999`.
  *Fallback:* Remove `runAsUser/Group` and keep `fsGroup` only if needed.
* **Slow cold starts:** Probes use conservative initial delays; adjust if needed on slow machines.

### Rollout / Rollback

* **Rollout:** `kubectl apply -f k8s/postgres/statefulset.yaml`
* **Rollback:** `kubectl delete -f k8s/postgres/statefulset.yaml` (⚠ data loss if PVCs are also removed). For safe rollback, delete the StatefulSet but **keep PVCs**.

### Follow-ups

* **K8S-08:** Add `k8s/postgres/service.yaml` (ClusterIP, name: `postgres`) to expose DB to the app.
* **Secrets:** Move credentials to Kubernetes Secrets for non-dev environments.
* **Backups:** Add backup/restore guidance for persistent data if needed.

### Testing / Verification Checklist

* [ ] StatefulSet pod is `READY 1/1`.
* [ ] PVC is `Bound`; no permission errors during `initdb`.
* [ ] `pg_isready` probes passing.
* [ ] Optional: `psql` query (`SELECT 1;`) succeeds inside the pod.

