### PR TITLE
K8S-08 — Add PostgreSQL ClusterIP Service (`postgres`)

### DIFF
--- a/k8s/postgres/service.yaml
+++ b/k8s/postgres/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: default
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432           # Service port exposed within the cluster
+      targetPort: postgres # Maps to the named port inside the Pod (named "postgres" in the StatefulSet)
+      protocol: TCP


### PR DESCRIPTION
Adds a dedicated **ClusterIP Service** for PostgreSQL so the app can connect via the stable in-cluster DNS name **`postgres:5432`**. This complements K8S-07’s headless service (`postgres-hl`) used by the StatefulSet and aligns with the app’s `DATABASE_URI`.

### What changed

* **New file:** `k8s/postgres/service.yaml`

  ```yaml
  apiVersion: v1
  kind: Service
  metadata:
    name: postgres
    namespace: default
    labels: { app: postgres }
  spec:
    type: ClusterIP
    selector: { app: postgres }
    ports:
      - name: postgres
        port: 5432
        targetPort: postgres
        protocol: TCP
  ```
* No changes to application code or CI.

### Motivation

The app’s `DATABASE_URI` is configured to use `...@postgres:5432/promotions`. Without a **ClusterIP Service** named `postgres`, connections rely on pod DNS or headless service endpoints and are not stable/idiomatic. This service provides a canonical endpoint for the Deployment to reach the DB.

### Dependencies

* **Requires:** K8S-07 (PostgreSQL StatefulSet + headless service) to be applied and the pod `postgres-0` to be Ready.
* **Works with:** K8S-04 (app Deployment using `DATABASE_URI`), K8S-05/06 (Service/Ingress for the app).

### Verification / Test Evidence

1. **Apply service**

   ```bash
   kubectl apply -f k8s/postgres/service.yaml
   kubectl get svc postgres -o wide
   ```
2. **Direct DB probe (optional)**

   ```bash
   kubectl port-forward svc/postgres 55432:5432
   PGPASSWORD=postgres psql -h 127.0.0.1 -p 55432 -U postgres -d promotions -c "SELECT 1;"
   # Expect one row with 1
   ```
3. **App end-to-end (optional)**

   * App pod should transition to Ready if it previously failed due to DB DNS.
   * If using Ingress (K3D):

     ```bash
     curl -i -H "Host: promotions.local" http://localhost:8080/health
     # Expect 200 {"status":"OK"}
     ```
   * Create/read a promotion (if POST/GET are enabled) to confirm DB writes.

### Backward compatibility / Risk

* **Risk:** Low. Adds an internal service only; no external exposure.
* **Rollback:** `kubectl delete svc postgres` (app will revert to previous behavior; if it depends on this DNS, app will log connection errors until recreated).

### Operational notes

* Default creds are `postgres/postgres` for dev only.
* If the app started before this service existed, a single `kubectl rollout restart deploy promotions-deployment` may be needed to reconnect.

### Follow-ups (nice to have)

* Move DB creds into **Kubernetes Secret** and wire via `envFrom`.
* Add a `make verify` smoke target that port-forwards `svc/postgres` and runs `SELECT 1`.
* Consider Helm/Jsonnet templating if more envs are planned.

