### PR TITLE
K8S-13: Add baseline resource requests/limits for app & database workloads

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -73,10 +73,10 @@ spec:
             failureThreshold: 3
 
           # If you need resource constraints, add requests/limits in K8S-13
-          # resources:
-          #   requests:
-          #     cpu: "100m"
-          #     memory: "128Mi"
-          #   limits:
-          #     cpu: "500m"
-          #     memory: "512Mi"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -77,6 +77,13 @@ spec:
           volumeMounts:
             - name: pgdata
               mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+
   volumeClaimTemplates:
     - metadata:
         name: pgdata


### PR DESCRIPTION
Introduce conservative resource requests/limits to make scheduling predictable and reduce OOM/throttling risk under normal load. App now has both CPU/memory requests & limits; Postgres has a memory limit and request plus a small CPU request, with **no CPU limit** to avoid throttling.

**Changes**

* `k8s/deployment.yaml` (app):

  ```yaml
  resources:
    requests:
      cpu: 100m
      memory: 128Mi
    limits:
      cpu: 500m
      memory: 512Mi
  ```
* `k8s/postgres/statefulset.yaml` (db, container spec):

  ```yaml
  resources:
    requests:
      cpu: 100m
      memory: 256Mi
    limits:
      memory: 1Gi
  ```

  *(Intentionally omit `cpu` limit for Postgres.)*

**Rationale**

* Provide baseline **requests** so the scheduler can make accurate placement/capacity decisions.
* Keep app **limits** modest to cap runaway usage while preserving headroom.
* Avoid a DB **CPU limit** to reduce Linux CFS throttling under routine spikes; DBs degrade poorly when CPU-capped.

**Validation**

* Manifests apply cleanly and roll out successfully:

  ```bash
  kubectl diff -f k8s/
  kubectl apply -f k8s/deployment.yaml
  kubectl apply -f k8s/postgres/statefulset.yaml
  kubectl rollout status deploy/promotions-deployment
  kubectl rollout status statefulset/postgres
  ```
* Resources visible on Pods:

  ```bash
  kubectl describe pod -l app=promotions
  kubectl describe pod -l app=postgres
  ```
* Runtime checks (normal load):

  ```bash
  # optional if metrics-server is installed
  kubectl top pods
  # existing smoke:
  make verify
  ```
* QoS class: **Burstable** for both workloads (expected).

**Impact**

* No changes to APIs, images, ports, volumes, or environment variables.
* Affects scheduling behavior only; runtime should remain stable under typical workloads.

**Risk & Rollback**

* Low risk; resource knobs only.
* Rollback: `kubectl rollout undo deploy/promotions-deployment` and `kubectl rollout undo statefulset/postgres`, or revert commit.

**Observability**

* Monitor for `OOMKilled` events and CPU throttling (`kubectl describe pod` events; cluster dashboards if available).
* If throttling observed on app, consider raising app CPU limit; if DB pressure occurs, revisit memory limit.

**Follow-ups (optional)**

* Tune app limits (e.g., `cpu: 750m`) after load testing.
* Re-assess DB memory limit with realistic dataset/workload.
