### PR TITLE
Add BDD tests workflow for headless browser testing

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -1,0 +1,66 @@
+name: BDD Tests
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+    - 'README.md'
+    - '.vscode/**'
+    - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+    - 'README.md'
+    - '.vscode/**'
+    - '**.md'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: quay.io/rofrano/pipeline-selenium:sp25
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_PASSWORD: pgs3cr3t
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip pipenv
+          pipenv install --system --dev
+
+      - name: Run the service locally
+        run: |
+          echo "\n*** STARTING APPLICATION ***\n"
+          gunicorn --log-level=info --bind=0.0.0.0:8080 wsgi:app &
+          echo "Waiting for service to stabilize..."
+          sleep 5
+          echo "Checking service /health..."
+          curl -i http://localhost:8080/health
+          echo "\n*** SERVER IS RUNNING ***"
+        env:
+          DATABASE_URI: "postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/testdb"
+
+      - name: Run Integration Tests
+        run: behave
+        env:
+          DRIVER: "chrome"


### PR DESCRIPTION
## What
| Feature | Description |
| :--- | :--- |
| **File Location** | `.github/workflows/bdd.yml` |
| **Triggers** | Push or Pull Request targeting the `master` branch (ignores changes to documentation). |
| **Execution Environment** | Uses `quay.io/rofrano/pipeline-selenium:sp25` (pre-installed with Chrome, ChromeDriver, and BDD tools). |
| **Service Dependencies** | Starts a PostgreSQL 15-alpine service to support the tests. |
| **Test Steps** | 1. **Run Service:** Starts the Flask app via `gunicorn` on port 8080. <br> 2. **Run Tests:** Executes Behave BDD tests using the Chrome driver in headless mode. |

## Why

The introduction of `bdd.yml` creates a clear separation of duties:

1.  `workflow.yml` (Existing) $\rightarrow$ Runs **Unit Tests** (`pytest`).
2.  `bdd.yml` (New) $\rightarrow$ Runs **BDD Integration Tests** (`behave`).